### PR TITLE
Update on actions/create-pull-request

### DIFF
--- a/actions/create-pull-request/Create-pull-request.md
+++ b/actions/create-pull-request/Create-pull-request.md
@@ -20,7 +20,8 @@ jobs:
         run: |
           # DO SOME CHANGES
       - name: Create Pull Request
-        uses: equinor/OmniaAutomation/actions/create-pull-request/v1@59cc56bba37fc1e089a31eed4b44357e4cafffc8 # See table for ref (Commit or tag)
+        uses: equinor/OmniaAutomation/actions/create-pull-request/v1@24ee309c6fc2d64e5b713e26c96c7ed5e74cf7de
+                                                                  # See table for ref (Commit or tag)
         with:
           Token: ${{ secrets.GITHUB_TOKEN }} # Required
           title: "Automatic update"
@@ -39,7 +40,7 @@ jobs:
 
 | Version |                Commit ref                |
 | :-----: | :--------------------------------------: |
-|   v1    | 59cc56bba37fc1e089a31eed4b44357e4cafffc8 |
+|   v1    | 24ee309c6fc2d64e5b713e26c96c7ed5e74cf7de |
 
 ## Limitations
 

--- a/actions/create-pull-request/dev/action.yml
+++ b/actions/create-pull-request/dev/action.yml
@@ -16,6 +16,9 @@ inputs:
   Token:
     description: "Github token for authentication when logging in to gh cli"
     required: true
+  commitMessage:
+    description: "The commit message in the dedicated branch"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -23,11 +26,12 @@ runs:
         write-host ($Env:GITHUB_WORKSPACE)
         $Env:GITHUB_TOKEN | gh auth login --with-token
         $PullRequestParameters = @{
-                                    Title     =     "${{ inputs.title }}"
-                                    Body      =     "${{ inputs.body }}"
-                                    Branch    =     "${{ inputs.dedicatedbranch }}"
+                                    Title         =     "${{ inputs.title }}"
+                                    Body          =     "${{ inputs.body }}"
+                                    Branch        =     "${{ inputs.dedicatedbranch }}"
+                                    commitMessage =     "${{ inputs.commitMessage }}"
                                   }
         & ${{ github.action_path }}/pull-request.ps1 @PullRequestParameters
       shell: pwsh
       env:
-        GITHUB_TOKEN: ${{ inputs.Token }} 
+        GITHUB_TOKEN: ${{ inputs.Token }}

--- a/actions/create-pull-request/dev/pull-request.ps1
+++ b/actions/create-pull-request/dev/pull-request.ps1
@@ -75,11 +75,12 @@ if ($PRstate -like "*CLOSED*" -or $PRstate -like "*MERGED*" -or $PRstate -like "
 else {
     # if pull request is active (open or draft). The pull request will try to create new pull request.
     try {
-        gh pr create --base $baseBranch --head $branch --title $title --body $body
+        gh pr create --base $baseBranch --head $branch --title $title --body $body -ErrorAction Stop
         write-host "A new pull request was created"
     }
     catch {
-        write-host "The pull request was updated"
+        write-host "A pull Request is already Open or in Draft from '$($remote)/$($branch)' to '$($remote)/$($baseBranch)'."
+        write-host "The Pull Request has been updated."
     }
 }
   

--- a/actions/create-pull-request/dev/pull-request.ps1
+++ b/actions/create-pull-request/dev/pull-request.ps1
@@ -67,20 +67,25 @@ git push --set-upstream $remote $branch -f
 # IMORTANT: Writing over current remote branch. The branch will have no commit history.
 git push --force
 
+if ($PRstate -ne "NONEXISTENT"){
+    try{
+        $PRstate = (gh pr view $branch)[1]
+    }
+    catch{
+        Write-Host "The last pull request was deleted."
+        $PRstate = "NONEXISTENT"
+    }
+}
+Write-Host "The current pull-request has $($PRstate)"
 # What state is the last pull request in?
 if ($PRstate -like "*CLOSED*" -or $PRstate -like "*MERGED*" -or $PRstate -like "*NONEXISTENT*") {
     # if pull request is not active, create new Pull Request
     gh pr create --base $baseBranch --head $branch --title $title --body $body
 }
 else {
-    # if pull request is active (open or draft). The pull request will try to create new pull request.
-    try {
-        gh pr create --base $baseBranch --head $branch --title $title --body $body -ErrorAction Stop
-        write-host "A new pull request was created"
-    }
-    catch {
-        write-host "A pull Request is already Open or in Draft from '$($remote)/$($branch)' to '$($remote)/$($baseBranch)'."
-        write-host "The Pull Request has been updated."
-    }
+    # if pull request is active (open or draft)
+
+    write-host "A pull Request is already Open or in Draft from '$($remote)/$($branch)' to '$($remote)/$($baseBranch)'."
+
 }
   

--- a/actions/create-pull-request/v1/action.yml
+++ b/actions/create-pull-request/v1/action.yml
@@ -16,6 +16,9 @@ inputs:
   Token:
     description: "Github token for authentication when logging in to gh cli"
     required: true
+  commitMessage:
+    description: "The commit message in the dedicated branch"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -23,11 +26,12 @@ runs:
         write-host ($Env:GITHUB_WORKSPACE)
         $Env:GITHUB_TOKEN | gh auth login --with-token
         $PullRequestParameters = @{
-                                    Title     =     "${{ inputs.title }}"
-                                    Body      =     "${{ inputs.body }}"
-                                    Branch    =     "${{ inputs.dedicatedbranch }}"
+                                    Title         =     "${{ inputs.title }}"
+                                    Body          =     "${{ inputs.body }}"
+                                    Branch        =     "${{ inputs.dedicatedbranch }}"
+                                    commitMessage =     "${{ inputs.commitMessage }}"
                                   }
         & ${{ github.action_path }}/pull-request.ps1 @PullRequestParameters
       shell: pwsh
       env:
-        GITHUB_TOKEN: ${{ inputs.Token }} 
+        GITHUB_TOKEN: ${{ inputs.Token }}

--- a/actions/create-pull-request/v1/pull-request.ps1
+++ b/actions/create-pull-request/v1/pull-request.ps1
@@ -2,7 +2,8 @@ param (
     [Parameter(Mandatory = $false)]$title = "Automated Pull Request",
     [Parameter(Mandatory = $false)]$branch = "automatic-pull-request",
     [Parameter(Mandatory = $false)]$body = "This is an automated pull request",
-    [Parameter(Mandatory = $false)]$remote = "origin"
+    [Parameter(Mandatory = $false)]$remote = "origin",
+    [Parameter(Mandatory = $false)]$commitMessage = "Create-Pull-Request commit"
 )
 
 $uniqueUserName = "github-actions-automated-pullrequest-$($branch)"
@@ -47,34 +48,44 @@ if ($RemoteString -like "*$branch*") {
     # Branch that is present in remote and has correct last author is expected to have a pull request history.
     $PRstate = (gh pr view $branch)[1]
 }
-else{
+else {
     # If new branch needs to be created, there is no pull request history.
     $PRstate = "NONEXISTENT"
     Write-Host "There is no remote branch named $($branch)"
 }
-# Pushing - set upstream to remote 
-git push --set-upstream $remote $branch -f
 # Adding changes
 git add .
 
+git commit -m $commitMessage
+# Pushing - set upstream to remote 
+$isDiff = (git diff "$($remote)/$($baseBranch)")
+if ($null -eq $isDiff) {
+    write-host "There is no changes. Exiting Create-Pull-Request action.."
+    exit
+}
+git push --set-upstream $remote $branch -f
+# IMORTANT: Writing over current remote branch. The branch will have no commit history.
+git push --force
+
+if ($PRstate -ne "NONEXISTENT"){
+    try{
+        $PRstate = (gh pr view $branch)[1]
+    }
+    catch{
+        Write-Host "The last pull request was deleted."
+        $PRstate = "NONEXISTENT"
+    }
+}
+Write-Host "The current pull-request has $($PRstate)"
 # What state is the last pull request in?
 if ($PRstate -like "*CLOSED*" -or $PRstate -like "*MERGED*" -or $PRstate -like "*NONEXISTENT*") {
     # if pull request is not active, create new Pull Request
-    git commit -m "Initial Commit Creating Pull Request"
-    # IMORTANT: Writing over current remote branch. The branch will have no commit history.
-    git push --force
     gh pr create --base $baseBranch --head $branch --title $title --body $body
 }
 else {
-    # if pull request is active (open or draft), this action will only push changes. The pull request will automatically update according to new changes.
-    git commit -m "Overwriting Pull Request with $($PRstate)"
-    git push --force
-    try {
-        gh pr create --base $baseBranch --head $branch --title $title --body $body
-        write-host "A new pull request was created"
-    }
-    catch {
-        write-host "The pull request was updated"
-    }
+    # if pull request is active (open or draft)
+
+    write-host "A pull Request is already Open or in Draft from '$($remote)/$($branch)' to '$($remote)/$($baseBranch)'."
+
 }
   


### PR DESCRIPTION
Update on v1.
Updated commit number in Create-Pull-Request documentation table. 
Added another check for Pull Request state after pushing to dedicated branch.
Removed try/catch 'gh pr create'. Did not seem to catch if failed.
Copied dev to v1.